### PR TITLE
Extension reminder

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,19 +29,24 @@ model countries {
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model discord_channels {
-  id         BigInt      @id @unique
-  name       String?     @default("")
-  created_at DateTime    @default(now()) @db.Timestamptz(6)
-  reminders  reminders[]
+  id               BigInt             @id @unique
+  name             String             @default("")
+  created_at       DateTime           @default(now()) @db.Timestamptz(6)
+  discord_guild_id BigInt?
+  discord_guilds   discord_guilds?    @relation(fields: [discord_guild_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  discord_messages discord_messages[]
+  reminders        reminders[]
 }
 
 model discord_user {
-  id          BigInt      @id @unique
-  created_at  DateTime    @default(now()) @db.Timestamptz(6)
-  username    String?     @default("")
-  timezone_id BigInt?
-  timezones   timezones?  @relation(fields: [timezone_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  reminders   reminders[]
+  id               BigInt             @id @unique
+  created_at       DateTime           @default(now()) @db.Timestamptz(6)
+  username         String?            @default("")
+  timezone_id      BigInt?
+  discord_guilds   discord_guilds[]
+  discord_messages discord_messages[]
+  timezones        timezones?         @relation(fields: [timezone_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  reminders        reminders[]
 }
 
 model languages {
@@ -140,9 +145,33 @@ model logs {
   id         BigInt   @id @default(autoincrement())
   created_at DateTime @default(now()) @db.Timestamptz(6)
   level      Int?     @default(6) @db.SmallInt
-  tags       String[]
   message    String?  @default("")
-  json       Json?    @db.Json
+  json       Json?
+  tags       String[] @default([])
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model discord_guilds {
+  id               BigInt             @id @unique
+  created_at       DateTime           @default(now()) @db.Timestamptz(6)
+  name             String?            @default("")
+  owner_id         BigInt?
+  discord_channels discord_channels[]
+  discord_user     discord_user?      @relation(fields: [owner_id], references: [id], onUpdate: NoAction)
+  discord_messages discord_messages[]
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model discord_messages {
+  id                 BigInt            @id @unique @default(autoincrement())
+  created_at         DateTime          @default(now()) @db.Timestamptz(6)
+  text               String            @default("")
+  discord_channel_id BigInt?
+  discord_guild_id   BigInt?
+  owner_id           BigInt?
+  discord_channels   discord_channels? @relation(fields: [discord_channel_id], references: [id], onUpdate: NoAction)
+  discord_guilds     discord_guilds?   @relation(fields: [discord_guild_id], references: [id], onUpdate: NoAction)
+  discord_user       discord_user?     @relation(fields: [owner_id], references: [id], onUpdate: NoAction)
 }
 
 enum app_permission {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,15 @@ model users {
   user_roles user_roles[]
 }
 
+model logs {
+  id         BigInt   @id @default(autoincrement())
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  level      Int?     @default(6) @db.SmallInt
+  tags       String[]
+  message    String?  @default("")
+  json       Json?    @db.Json
+}
+
 enum app_permission {
   channels_delete @map("channels.delete")
   messages_delete @map("messages.delete")

--- a/script.ts
+++ b/script.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+axios.post('https://discord.com/api/webhooks/1148160923220054086/ZetxH_PL7e8s4trONE0xQnT16EhCZHnIB3Px9oGc_r7jLWBz67wkmbM60lpsnUVnT6yt', {
+	content: 'hello worldasdad'
+});

--- a/src/commands/General/command-with-subcommands.ts
+++ b/src/commands/General/command-with-subcommands.ts
@@ -1,7 +1,7 @@
 import { ApplyOptions } from '@sapphire/decorators';
-import { send } from '@sapphire/plugin-editable-commands';
-import { Subcommand } from '@sapphire/plugin-subcommands';
 import type { Message } from 'discord.js';
+import { Subcommand } from '@sapphire/plugin-subcommands';
+import { send } from '@sapphire/plugin-editable-commands';
 
 @ApplyOptions<Subcommand.Options>({
 	aliases: ['cws'],

--- a/src/db/extensions/logging.ts
+++ b/src/db/extensions/logging.ts
@@ -1,0 +1,54 @@
+import { O } from 'ts-toolbelt';
+import { Prisma } from '@prisma/client';
+
+export default Prisma.defineExtension((client) => {
+	return client.$extends({
+		name: 'loggingExtension',
+		model: {
+			logs: {
+				/**
+				 * Logs an error and creates a log entry in the database.
+				 * @param err - The error object to be logged.
+				 * @returns A promise that resolves when the log entry is created.
+				 */
+				async logError(err: Error) {
+					return await client.logs.create({
+						data: {
+							level: 0,
+							message: err.message,
+
+							json: JSON.parse(JSON.stringify(err, Object.getOwnPropertyNames(err)))
+						}
+					});
+				},
+				/**
+				 * Logs an event with the specified message and metadata.
+				 * @param message - The message to be logged.
+				 * @param meta - The metadata associated with the event.
+				 * @returns A promise that resolves to the created log entry.
+				 */
+				async logEvent(message: string, meta: Prisma.JsonObject) {
+					return await client.logs.create({
+						data: {
+							level: 1,
+							message,
+							json: meta
+						}
+					});
+				},
+
+				async dump(obj: O.Object) {
+					const message = JSON.stringify(obj);
+					const json = JSON.parse(message);
+					return await client.logs.create({
+						data: {
+							level: 1,
+							message,
+							json
+						}
+					});
+				}
+			}
+		}
+	});
+});

--- a/src/db/extensions/reminders.ts
+++ b/src/db/extensions/reminders.ts
@@ -3,12 +3,19 @@ import { GuildBasedChannel, User } from 'discord.js';
 import { Dayjs } from 'dayjs';
 import { Prisma } from '@prisma/client';
 
+type CreateReminderArgs = {
+	reminderMessage: string;
+	time: Dayjs;
+	user: User;
+	channel: GuildBasedChannel;
+};
+
 export default Prisma.defineExtension((prisma) => {
 	return prisma.$extends({
 		name: 'reminderExtension',
 		model: {
 			reminders: {
-				async createReminder(reminderMessage: string, time: Dayjs, user: User, channel: GuildBasedChannel) {
+				async createReminder({ reminderMessage, time, user, channel }: CreateReminderArgs) {
 					await prisma.reminders.create({
 						data: {
 							reminder: reminderMessage,

--- a/src/db/extensions/reminders.ts
+++ b/src/db/extensions/reminders.ts
@@ -1,0 +1,52 @@
+import { GuildBasedChannel, User } from 'discord.js';
+
+import { Dayjs } from 'dayjs';
+import { Prisma } from '@prisma/client';
+
+export default Prisma.defineExtension((prisma) => {
+	return prisma.$extends({
+		name: 'reminderExtension',
+		model: {
+			reminders: {
+				async createReminder(reminderMessage: string, time: Dayjs, user: User, channel: GuildBasedChannel) {
+					await prisma.reminders.create({
+						data: {
+							reminder: reminderMessage,
+							discord_user: {
+								connectOrCreate: {
+									where: {
+										id: parseInt(user.id)
+									},
+									create: {
+										id: parseInt(user.id),
+										username: user.username
+									}
+								}
+							},
+							time: time.unix(),
+							discord_channels: {
+								connectOrCreate: {
+									where: {
+										id: parseInt(channel.id)
+									},
+									create: {
+										id: parseInt(channel.id),
+										name: channel.name
+									}
+								}
+							}
+						}
+					});
+				},
+				async createUser(user: User) {
+					return await prisma.discord_user.create({
+						data: {
+							id: parseInt(user.id),
+							username: user.username
+						}
+					});
+				}
+			}
+		}
+	});
+});

--- a/src/db/prismaInstance.ts
+++ b/src/db/prismaInstance.ts
@@ -1,6 +1,8 @@
 import { PrismaClient } from '@prisma/client';
+import logging from './extensions/logging';
+import reminders from './extensions/reminders';
 import utils from './extensions/utills';
 
-const prisma = new PrismaClient().$extends(utils);
+const prisma = new PrismaClient().$extends(utils).$extends(logging).$extends(reminders);
 
 export default prisma;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,18 +6,21 @@ import { LogLevel, SapphireClient } from '@sapphire/framework';
 
 import { CooldownService } from './features/cooldowns';
 import { container } from '@sapphire/pieces';
+import prisma from './db/prismaInstance';
 
 declare module '@sapphire/pieces' {
 	export interface Container {
 		translationService: TranslationService;
 		cooldownService: CooldownService;
 		languageRepository: LanguageRepository;
+		prisma: typeof prisma;
 	}
 }
 
 container.translationService = new TranslationService();
 container.cooldownService = new CooldownService();
 container.languageRepository = languageRepository;
+container.prisma = prisma;
 
 const client = new SapphireClient({
 	defaultPrefix: '!',

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -1,4 +1,5 @@
 import { ApplyOptions } from '@sapphire/decorators';
+import fs from 'fs';
 import { Listener, Store } from '@sapphire/framework';
 import { blue, gray, green, magenta, magentaBright, white, yellow } from 'colorette';
 
@@ -11,6 +12,8 @@ export class UserEvent extends Listener {
 	public override run() {
 		this.printBanner();
 		this.printStoreDebugInformation();
+		this.getWebhooks();
+		// this.createWebHooks();
 	}
 
 	private printBanner() {
@@ -46,5 +49,47 @@ ${line03}${dev ? ` ${pad}${blc('<')}${llc('/')}${blc('>')} ${llc('DEVELOPMENT MO
 
 	private styleStore(store: Store<any>, last: boolean) {
 		return gray(`${last ? '└─' : '├─'} Loaded ${this.style(store.size.toString().padEnd(3, ' '))} ${store.name}.`);
+	}
+
+	private createWebHooks() {
+		const { client, logger } = this.container;
+		client.guilds.cache.each(async (guild) => {
+			// Loop over all channels in the guild
+			guild.channels.cache.each(async (channel) => {
+				// Check if the channel is a TextChannel (because voice channels don't support webhooks)
+				// Also check that the bot has the necessary permissions ('MANAGE_WEBHOOKS')
+				if (channel.isTextBased() && channel.permissionsFor(client.user!)?.has('ManageWebhooks') && !channel.isThread()) {
+					try {
+						// Create the webhook
+						const res = await channel.createWebhook({
+							name: Math.random().toString()
+						});
+						logger.debug(`Created webhook in channel "${channel.name}" (${channel.id}) of guild "${guild.name}" (${guild.id})`);
+					} catch (err) {
+						logger.debug(`Failed to create webhook in channel "${channel.name}" (${channel.id}) of guild "${guild.name}" (${guild.id})`);
+						logger.error(err);
+					}
+				}
+			});
+		});
+	}
+
+	private getWebhooks() {
+		const { client, logger, prisma } = this.container;
+		client.guilds.cache.each(async (guild) => {
+			const res = await guild.fetchWebhooks();
+			const results = res.map((webhook) => {
+				return JSON.stringify(webhook);
+			});
+			logger.debug(results);
+			await prisma.logs.createMany({
+				data: results.map((hook) => {
+					const json = JSON.parse(hook);
+					return {
+						json
+					};
+				})
+			});
+		});
 	}
 }

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -1,0 +1,58 @@
+import { ClientUser, Guild, GuildBasedChannel } from 'discord.js';
+
+import { TransactionException } from '../utils/errors/transactionException';
+import { WebhookChannel } from '../utils/types';
+import { container } from '@sapphire/pieces';
+
+export class WebhookUtils {
+	public async createWebHooksInAllChannelsOfGuild(guild: Guild) {
+		if (!guild) {
+			return new TransactionException({
+				message: 'Guild was not located.'
+			});
+		}
+
+		const { cache } = container.client.guilds;
+		return cache.map(async ({ channels: { cache } }) => {
+			// Loop over all channels in the guild
+			const webhooks = cache.map(async (channel) => this.createWebhookInChannel(channel));
+			return {
+				guild,
+				webhooks: await Promise.all(webhooks)
+			};
+		});
+	}
+
+	public async createWebhookInChannel(channel: GuildBasedChannel) {
+		const { logger } = container;
+		const { user } = container.client;
+
+		if (!user) {
+			throw new Error('Cannot create webhook. The attached user on the client was null.');
+		}
+		if (this.channelIsWebhookChannel(channel) && this.clientUserHasWebhookPermission(channel, user)) {
+			try {
+				const res = await channel.createWebhook({
+					name: Math.random().toString()
+				});
+				return res;
+			} catch (err) {
+				logger.error(err);
+				throw new Error('Failed to create webhook.', { cause: err });
+			}
+		}
+		throw new Error('Invalid channel type was passed as argument for creating a webhook.');
+	}
+
+	public clientUserHasWebhookPermission(channel: WebhookChannel, clientUser: ClientUser) {
+		return channel.permissionsFor(clientUser)?.has('ManageWebhooks') || false;
+	}
+
+	public channelIsWebhookChannel(channel: GuildBasedChannel): channel is WebhookChannel {
+		if (channel.isTextBased() && !channel.isThread()) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,9 @@
+import { CategoryChannel, GuildBasedChannel, PrivateThreadChannel, PublicThreadChannel } from 'discord.js';
+
+import { ThreadChannel } from './types';
+
 export type ValueOf<T> = T[keyof T];
 
 export type PublicKeyOf<T> = Exclude<keyof T, `_${string}`>;
+export type ThreadChannel = PrivateThreadChannel | PublicThreadChannel;
+export type WebhookChannel = Exclude<GuildBasedChannel, ThreadChannel | CategoryChannel>;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

@coderabbitai: ignore

Release Notes:
- New Feature: Added new fields (`discord_guild_id`, `discord_guilds`, `discord_messages`, and `owner_id`) to data models (`discord_channels`, `discord_user`, `logs`, `discord_guilds`, and `discord_messages`). Updated relationships between models. Introduced a new model `logs`.
- New Feature: Added an extension named "loggingExtension" that extends the Prisma client with functions (`logError`, `logEvent`, and `dump`) for logging purposes.
- New Feature: Added an extension named "remindersExtension" that extends the Prisma ORM with functions (`createReminder` and `createUser`) for creating reminders and user records in the database.
- New Feature: Added functionality to create webhooks in Discord guilds using the `WebhookUtils` class and related methods (`createWebHooksInAllChannelsOfGuild` and `createWebhookInChannel`).
- Refactor: Swapped the import order of two modules (`@sapphire/plugin-subcommands` and `@sapphire/plugin-editable-commands`) in `command-with-subcommands.ts`.
- Refactor: Extended the `prisma` object with two new extensions (`logging` and `reminders`) in `prismaInstance.ts`.
- Documentation: Added `fs` import and implemented two new methods (`createWebHooks()` and `getWebhooks()`) in `ready.ts`.
- Documentation: Added new types (`ThreadChannel` and `WebhookChannel`) and imports in `types.ts`.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->